### PR TITLE
Implementar token como alternativa a UUIDs para a identificação de sessão 

### DIFF
--- a/internal/almodon/app.go
+++ b/internal/almodon/app.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/alan-b-lima/almodon/internal/domain"
-	"github.com/alan-b-lima/almodon/internal/support/session"
+	sessions "github.com/alan-b-lima/almodon/internal/domain/session/resource"
 	"github.com/alan-b-lima/almodon/ui/web"
 )
 
@@ -33,7 +33,7 @@ func New() (*Almodon, error) {
 
 	a.mux.Handle("/toolkit/", toolkit)
 	a.mux.Handle("/docs/", docs)
-	a.mux.Handle("/api/", session.Wrap(api))
+	a.mux.Handle("/api/", sessions.Wrap(api))
 
 	return &a, nil
 }

--- a/internal/domain/auth/resource/http.go
+++ b/internal/domain/auth/resource/http.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	"github.com/alan-b-lima/almodon/internal/domain/auth"
+	sessions "github.com/alan-b-lima/almodon/internal/domain/session/resource"
 	"github.com/alan-b-lima/almodon/internal/support/resource"
-	"github.com/alan-b-lima/almodon/internal/support/session"
 )
 
 type Resource struct {
@@ -39,14 +39,14 @@ func (rc *Resource) Login(w http.ResponseWriter, r *http.Request) {
 			return auth.Result{}, err
 		}
 
-		session.SetCookie(w, res.UUID, res.Expires)
+		sessions.SetCookie(w, res.Token, res.Expires)
 		return res, nil
 	}, w, r)
 }
 
 func (rc *Resource) Logout(w http.ResponseWriter, r *http.Request) {
 	resource.DeleteHandler(r.Context(), func(ctx context.Context) error {
-		s, err := session.Cookie(r)
+		s, err := sessions.Cookie(r)
 		if err != nil {
 			return nil
 		}
@@ -55,7 +55,7 @@ func (rc *Resource) Logout(w http.ResponseWriter, r *http.Request) {
 			return nil
 		}
 
-		session.DeleteCookie(w)
+		sessions.DeleteCookie(w)
 		return nil
 	}, w, r)
 }

--- a/internal/domain/auth/service.go
+++ b/internal/domain/auth/service.go
@@ -4,18 +4,19 @@ import (
 	"context"
 	"time"
 
+	"github.com/alan-b-lima/almodon/internal/domain/session"
 	"github.com/alan-b-lima/almodon/pkg/uuid"
 )
 
 type Service interface {
-	Login(ctx context.Context, siape string, password string) (Result, error)
-	Logout(ctx context.Context, session uuid.UUID) error
+	Login(ctx context.Context, siape, password string) (Result, error)
+	Logout(ctx context.Context, session session.Token) error
 
 	Authenticator
 }
 
 type Authenticator interface {
-	Actor(ctx context.Context, session uuid.UUID) (Actor, error)
+	Actor(ctx context.Context, session session.Token) (Actor, error)
 }
 
 type (
@@ -27,8 +28,8 @@ type (
 
 type (
 	Result struct {
-		UUID    uuid.UUID `json:"-"`
-		User    uuid.UUID `json:"user"`
-		Expires time.Time `json:"expires"`
+		Token   session.Token `json:"-"`
+		User    uuid.UUID     `json:"user"`
+		Expires time.Time     `json:"expires"`
 	}
 )

--- a/internal/domain/auth/service/core.go
+++ b/internal/domain/auth/service/core.go
@@ -6,8 +6,6 @@ import (
 	"github.com/alan-b-lima/almodon/internal/domain/auth"
 	"github.com/alan-b-lima/almodon/internal/domain/session"
 	"github.com/alan-b-lima/almodon/internal/domain/user"
-
-	"github.com/alan-b-lima/almodon/pkg/uuid"
 )
 
 type Core struct {
@@ -34,24 +32,23 @@ func (c *Core) Login(ctx context.Context, siape string, password string) (auth.R
 		return auth.Result{}, err
 	}
 
-	sres, err := c.Sessions.CreateAndGet(ctx, session.Create{User: res.UUID})
+	sres, err := c.Sessions.Create(ctx, session.Create{User: res.UUID})
 	if err != nil {
 		return auth.Result{}, err
 	}
 
-	ares := auth.Result{
-		UUID:    sres.UUID,
-		User:    res.UUID,
+	return auth.Result{
+		Token:   sres.Token,
+		User:    sres.User,
 		Expires: sres.Expires,
-	}
-	return ares, nil
+	}, nil
 }
 
-func (c *Core) Logout(ctx context.Context, session uuid.UUID) error {
+func (c *Core) Logout(ctx context.Context, session session.Token) error {
 	return c.Sessions.Delete(ctx, session)
 }
 
-func (c *Core) Actor(ctx context.Context, session uuid.UUID) (auth.Actor, error) {
+func (c *Core) Actor(ctx context.Context, session session.Token) (auth.Actor, error) {
 	res, err := c.Sessions.Get(ctx, session)
 	if err != nil {
 		return auth.NewUnlogged(), auth.ErrUnauthenticated.Cause(err).Make()

--- a/internal/domain/session/entity.go
+++ b/internal/domain/session/entity.go
@@ -30,7 +30,7 @@ func ProcessMaxAge(max_age time.Duration) (time.Time, error) {
 	return expires, nil
 }
 
-const TokenLen = 32
+const TokenLen = 24
 
 type Token [TokenLen]byte
 
@@ -48,7 +48,7 @@ func (t *Token) Bytes() []byte {
 var _Format = `%0` + strconv.Itoa(2*TokenLen) + `x`
 
 func (t Token) String() string {
-	return fmt.Sprintf(_Format, t)
+	return fmt.Sprintf(_Format, t[:])
 }
 
 func FromString(string string) (Token, error) {
@@ -58,11 +58,12 @@ func FromString(string string) (Token, error) {
 
 	var token Token
 	for i := range TokenLen {
-		b, err := strconv.ParseInt(string[:2], 16, 8)
+		b, err := strconv.ParseUint(string[:2], 16, 8)
 		if err != nil {
 			return Token{}, ErrInvalidToken
 		}
 
+		string = string[2:]
 		token[i] = byte(b)
 	}
 

--- a/internal/domain/session/entity.go
+++ b/internal/domain/session/entity.go
@@ -1,7 +1,9 @@
 package session
 
 import (
+	"fmt"
 	"math"
+	"strconv"
 	"time"
 )
 
@@ -26,4 +28,43 @@ func ProcessMaxAge(max_age time.Duration) (time.Time, error) {
 
 	expires := time.Now().Add(max_age)
 	return expires, nil
+}
+
+const TokenLen = 32
+
+type Token [TokenLen]byte
+
+func NewToken() Token {
+	var token Token
+	read(token[:])
+
+	return token
+}
+
+func (t *Token) Bytes() []byte {
+	return t[:]
+}
+
+var _Format = `%0` + strconv.Itoa(2*TokenLen) + `x`
+
+func (t Token) String() string {
+	return fmt.Sprintf(_Format, t)
+}
+
+func FromString(string string) (Token, error) {
+	if 2*TokenLen != len(string) {
+		return Token{}, ErrInvalidToken
+	}
+
+	var token Token
+	for i := range TokenLen {
+		b, err := strconv.ParseInt(string[:2], 16, 8)
+		if err != nil {
+			return Token{}, ErrInvalidToken
+		}
+
+		token[i] = byte(b)
+	}
+
+	return token, nil
 }

--- a/internal/domain/session/entity_test.go
+++ b/internal/domain/session/entity_test.go
@@ -1,0 +1,22 @@
+package session_test
+
+import (
+	"testing"
+
+	. "github.com/alan-b-lima/almodon/internal/domain/session"
+)
+
+func TestInversabilityBetweenStringAndFromString(t *testing.T) {
+	const num_tests = 1000
+
+	for range num_tests {
+		token := NewToken()
+
+		str := token.String()
+		if back, err := FromString(str); err != nil {
+			t.Error(err)
+		} else if token != back {
+			t.Errorf("%x and %x should be equal", token, back)
+		}
+	}
+}

--- a/internal/domain/session/resource/session.go
+++ b/internal/domain/session/resource/session.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alan-b-lima/almodon/internal/support/resource"
 )
 
+// on malformed session token, clear the token and let the user proceed as unlogged.
 type Handler struct {
 	Handler http.Handler
 }
@@ -24,10 +25,17 @@ func WrapFunc(handler http.HandlerFunc) http.Handler {
 }
 
 func (s *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, err := Session(r.Context(), r)
-	if err != nil {
-		resource.WriteError(w, err)
-		return
+	ctx := r.Context()
+
+	if c, err := Session(ctx, r); err != nil {
+		if err != session.ErrInvalidToken {
+			resource.WriteError(w, err)
+			return
+		}
+
+		DeleteCookie(w)
+	} else {
+		ctx = c
 	}
 
 	r = r.WithContext(ctx)
@@ -57,7 +65,7 @@ func Cookie(r *http.Request) (session.Token, error) {
 
 	token, err := session.FromString(s.Value)
 	if err != nil {
-		return session.Token{}, resource.ErrBadUUID
+		return session.Token{}, session.ErrInvalidToken
 	}
 
 	return token, nil

--- a/internal/domain/session/resource/session.go
+++ b/internal/domain/session/resource/session.go
@@ -1,12 +1,12 @@
-package session
+package sessions
 
 import (
 	"context"
 	"net/http"
 	"time"
 
+	"github.com/alan-b-lima/almodon/internal/domain/session"
 	"github.com/alan-b-lima/almodon/internal/support/resource"
-	"github.com/alan-b-lima/almodon/pkg/uuid"
 )
 
 type Handler struct {
@@ -49,24 +49,24 @@ func Session(ctx context.Context, r *http.Request) (context.Context, error) {
 	return context.WithValue(ctx, "session", session), nil
 }
 
-func Cookie(r *http.Request) (uuid.UUID, error) {
+func Cookie(r *http.Request) (session.Token, error) {
 	s, err := r.Cookie(SessionIdentifier)
 	if err != nil {
-		return uuid.UUID{}, http.ErrNoCookie
+		return session.Token{}, http.ErrNoCookie
 	}
 
-	session, err := uuid.FromString(s.Value)
+	token, err := session.FromString(s.Value)
 	if err != nil {
-		return uuid.UUID{}, resource.ErrBadUUID
+		return session.Token{}, resource.ErrBadUUID
 	}
 
-	return session, nil
+	return token, nil
 }
 
-func SetCookie(w http.ResponseWriter, uuid uuid.UUID, expires time.Time) {
+func SetCookie(w http.ResponseWriter, token session.Token, expires time.Time) {
 	cookie := &http.Cookie{
 		Name:     SessionIdentifier,
-		Value:    uuid.String(),
+		Value:    token.String(),
 		Expires:  expires,
 		Path:     "/",
 		HttpOnly: true,

--- a/internal/domain/session/service.go
+++ b/internal/domain/session/service.go
@@ -9,13 +9,13 @@ import (
 )
 
 type Service interface {
-	Get(context.Context, uuid.UUID) (Result, error)
+	Get(context.Context, Token) (Result, error)
 
-	CreateAndGet(context.Context, Create) (Result, error)
+	Create(context.Context, Create) (Result, error)
 
-	Update(context.Context, uuid.UUID, Update) error
+	Update(context.Context, Token, Update) error
 
-	Delete(context.Context, uuid.UUID) error
+	Delete(context.Context, Token) error
 }
 
 type (
@@ -31,7 +31,7 @@ type (
 
 type (
 	Result struct {
-		UUID    uuid.UUID `json:"-"`
+		Token   Token     `json:"-"`
 		User    uuid.UUID `json:"user"`
 		Renewed int       `json:"renewed"`
 		Expires time.Time `json:"expires"`

--- a/internal/domain/session/service/core.go
+++ b/internal/domain/session/service/core.go
@@ -7,8 +7,6 @@ import (
 	"github.com/alan-b-lima/almodon/internal/domain/session"
 	"github.com/alan-b-lima/almodon/internal/support/service"
 
-	"github.com/alan-b-lima/almodon/pkg/uuid"
-
 	"github.com/alan-b-lima/pkg/problem"
 	"github.com/alan-b-lima/pkg/scheduler"
 )
@@ -29,8 +27,8 @@ func New(sessions session.Store, scheduler *scheduler.Scheduler) *Core {
 
 const _MaxAge = 1 * time.Hour
 
-func (c *Core) Get(ctx context.Context, uuid uuid.UUID) (session.Result, error) {
-	res, err := c.Sessions.Get(ctx, uuid)
+func (c *Core) Get(ctx context.Context, token session.Token) (session.Result, error) {
+	res, err := c.Sessions.Get(ctx, token)
 	if err != nil {
 		return session.Result{}, err
 	}
@@ -43,7 +41,7 @@ func (c *Core) Get(ctx context.Context, uuid uuid.UUID) (session.Result, error) 
 }
 
 // TODO: verify validity of [_MaxAge] and turn it to an internal error
-func (c *Core) CreateAndGet(ctx context.Context, req session.Create) (session.Result, error) {
+func (c *Core) Create(ctx context.Context, req session.Create) (session.Result, error) {
 	max_age := _MaxAge
 	if v, ok := req.MaxAge.Unwrap(); ok {
 		max_age = v
@@ -59,7 +57,7 @@ func (c *Core) CreateAndGet(ctx context.Context, req session.Create) (session.Re
 	}
 
 	rec.User = req.User
-	rec.UUID = uuid.NewUUIDv7()
+	rec.Token = session.NewToken()
 	rec.Created = time.Now()
 
 	err = c.Sessions.RunTx(ctx, func(store session.Store) error {
@@ -69,7 +67,7 @@ func (c *Core) CreateAndGet(ctx context.Context, req session.Create) (session.Re
 				return err
 			}
 
-			if err := store.Delete(ctx, s.UUID); err != nil {
+			if err := store.Delete(ctx, s.Token); err != nil {
 				return err
 			}
 		}
@@ -86,7 +84,7 @@ func (c *Core) CreateAndGet(ctx context.Context, req session.Create) (session.Re
 }
 
 // TODO: verify validity of _MaxAge and turn it to an internal error
-func (c *Core) Update(ctx context.Context, uuid uuid.UUID, req session.Update) error {
+func (c *Core) Update(ctx context.Context, token session.Token, req session.Update) error {
 	max_age := _MaxAge
 	if v, ok := req.MaxAge.Unwrap(); ok {
 		max_age = v
@@ -94,7 +92,7 @@ func (c *Core) Update(ctx context.Context, uuid uuid.UUID, req session.Update) e
 
 	var expires time.Time
 	err := c.Sessions.RunTx(ctx, func(store session.Store) error {
-		s, err := store.Get(ctx, uuid)
+		s, err := store.Get(ctx, token)
 		if err != nil {
 			return err
 		}
@@ -109,7 +107,7 @@ func (c *Core) Update(ctx context.Context, uuid uuid.UUID, req session.Update) e
 		}
 
 		expires = rec.Expires
-		return c.Sessions.Update(ctx, uuid, rec)
+		return c.Sessions.Update(ctx, token, rec)
 	})
 	if err != nil {
 		return err
@@ -119,8 +117,8 @@ func (c *Core) Update(ctx context.Context, uuid uuid.UUID, req session.Update) e
 	return nil
 }
 
-func (c *Core) Delete(ctx context.Context, uuid uuid.UUID) error {
-	return c.Sessions.Delete(ctx, uuid)
+func (c *Core) Delete(ctx context.Context, token session.Token) error {
+	return c.Sessions.Delete(ctx, token)
 }
 
 func (c *Core) Publish(ctx context.Context) error {

--- a/internal/domain/session/store.go
+++ b/internal/domain/session/store.go
@@ -10,14 +10,14 @@ import (
 type Store interface {
 	List(context.Context) ([]Record, error)
 
-	Get(context.Context, uuid.UUID) (Record, error)
+	Get(context.Context, Token) (Record, error)
 	GetByUser(context.Context, uuid.UUID) (Record, error)
 
 	Create(context.Context, CreateRecord) error
 
-	Update(context.Context, uuid.UUID, UpdateRecord) error
+	Update(context.Context, Token, UpdateRecord) error
 
-	Delete(context.Context, uuid.UUID) error
+	Delete(context.Context, Token) error
 	DeleteExpired(context.Context, time.Time) error
 
 	RunTx(context.Context, func(Store) error) error
@@ -25,7 +25,7 @@ type Store interface {
 
 type (
 	Record struct {
-		UUID    uuid.UUID
+		Token   Token
 		User    uuid.UUID
 		Renewed int
 		Expires time.Time
@@ -35,7 +35,7 @@ type (
 
 type (
 	CreateRecord struct {
-		UUID    uuid.UUID
+		Token   Token
 		User    uuid.UUID
 		Renewed int
 		Expires time.Time

--- a/internal/domain/session/store/sqlite.go
+++ b/internal/domain/session/store/sqlite.go
@@ -9,13 +9,11 @@ import (
 	"github.com/alan-b-lima/almodon/internal/support/service"
 	"github.com/alan-b-lima/almodon/internal/support/store"
 	"github.com/alan-b-lima/almodon/pkg/uuid"
-
-	"github.com/alan-b-lima/pkg/problem"
 )
 
 const Table = `
 create table if not exists Sessions (
-	uuid    blob primary key,
+	token   blob primary key,
 	user    blob not null,
 	renewed int not null,
 	expires datetime not null,
@@ -24,8 +22,7 @@ create table if not exists Sessions (
 	foreign key (user) references Users(uuid)
 );`
 
-const Indexes = `
-create index if not exists Sessions_user on Sessions(user);`
+const Indexes = `create index if not exists Sessions_user on Sessions(user);`
 
 type SQLDB struct {
 	db store.DBTx
@@ -59,8 +56,8 @@ func (s *SQLDB) List(ctx context.Context) ([]session.Record, error) {
 	return recs, nil
 }
 
-func (s *SQLDB) Get(ctx context.Context, uuid uuid.UUID) (session.Record, error) {
-	return s.get(s.db.QueryRowContext(ctx, get, uuid.Bytes()))
+func (s *SQLDB) Get(ctx context.Context, token session.Token) (session.Record, error) {
+	return s.get(s.db.QueryRowContext(ctx, get, token.Bytes()))
 }
 
 func (s *SQLDB) GetByUser(ctx context.Context, user uuid.UUID) (session.Record, error) {
@@ -81,7 +78,7 @@ func (s *SQLDB) get(row *sql.Row) (session.Record, error) {
 }
 
 func (s *SQLDB) Create(ctx context.Context, rec session.CreateRecord) error {
-	_, err := s.db.ExecContext(ctx, create, rec.UUID.Bytes(), rec.User.Bytes(), rec.Renewed, rec.Expires, rec.Created)
+	_, err := s.db.ExecContext(ctx, create, rec.Token.Bytes(), rec.User.Bytes(), rec.Renewed, rec.Expires, rec.Created)
 	if err != nil {
 		return store.ErrExec.Cause(err).Make()
 	}
@@ -89,8 +86,8 @@ func (s *SQLDB) Create(ctx context.Context, rec session.CreateRecord) error {
 	return nil
 }
 
-func (s *SQLDB) Update(ctx context.Context, uuid uuid.UUID, rec session.UpdateRecord) error {
-	res, err := s.db.ExecContext(ctx, update, rec.Renewed, rec.Expires, uuid.Bytes())
+func (s *SQLDB) Update(ctx context.Context, token session.Token, rec session.UpdateRecord) error {
+	res, err := s.db.ExecContext(ctx, update, rec.Renewed, rec.Expires, token.Bytes())
 	if err != nil {
 		return store.ErrExec.Cause(err).Make()
 	}
@@ -103,8 +100,8 @@ func (s *SQLDB) Update(ctx context.Context, uuid uuid.UUID, rec session.UpdateRe
 	return nil
 }
 
-func (s *SQLDB) Delete(ctx context.Context, uuid uuid.UUID) error {
-	_, err := s.db.ExecContext(ctx, delete, uuid.Bytes())
+func (s *SQLDB) Delete(ctx context.Context, token session.Token) error {
+	_, err := s.db.ExecContext(ctx, delete, token.Bytes())
 	if err != nil {
 		return store.ErrExec.Cause(err).Make()
 	}
@@ -128,25 +125,22 @@ func (s *SQLDB) RunTx(ctx context.Context, proc func(session.Store) error) error
 }
 
 func scan(ent *session.Record, scanner store.Scanner) error {
-	var bytes1, bytes2 []byte
+	var bytes []byte
 
-	if err := scanner.Scan(&bytes1, &bytes2, &ent.Renewed, &ent.Expires, &ent.Created); err != nil {
+	if err := scanner.Scan(ent.Token.Bytes(), &bytes, &ent.Renewed, &ent.Expires, &ent.Created); err != nil {
 		return err
 	}
 
-	return problem.Join(
-		service.Set(&ent.UUID, bytes1, uuid.FromBytes),
-		service.Set(&ent.User, bytes2, uuid.FromBytes),
-	)
+	return service.Set(&ent.User, bytes, uuid.FromBytes)
 }
 
 const (
-	list        = `select uuid, user, renewed, expires, created from Sessions`
-	get         = list + ` where uuid = ?`
+	list        = `select token, user, renewed, expires, created from Sessions`
+	get         = list + ` where token = ?`
 	get_by_user = list + ` where user = ?`
 
-	create         = `insert into Sessions (uuid, user, renewed, expires, created) values (?, ?, ?, ?, ?)`
-	update         = `update Sessions set renewed = ?, expires = ? where uuid = ?`
-	delete         = `delete from Sessions where uuid = ?`
+	create         = `insert into Sessions (token, user, renewed, expires, created) values (?, ?, ?, ?, ?)`
+	update         = `update Sessions set renewed = ?, expires = ? where token = ?`
+	delete         = `delete from Sessions where token = ?`
 	delete_expired = `delete from Sessions where expires < ?`
 )

--- a/internal/domain/session/store/sqlite.go
+++ b/internal/domain/session/store/sqlite.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alan-b-lima/almodon/internal/support/service"
 	"github.com/alan-b-lima/almodon/internal/support/store"
 	"github.com/alan-b-lima/almodon/pkg/uuid"
+	"github.com/alan-b-lima/pkg/problem"
 )
 
 const Table = `
@@ -125,13 +126,31 @@ func (s *SQLDB) RunTx(ctx context.Context, proc func(session.Store) error) error
 }
 
 func scan(ent *session.Record, scanner store.Scanner) error {
-	var bytes []byte
+	var bytes1, bytes2 []byte
 
-	if err := scanner.Scan(ent.Token.Bytes(), &bytes, &ent.Renewed, &ent.Expires, &ent.Created); err != nil {
+	err := scanner.Scan(
+		&bytes1,
+		&bytes2,
+		&ent.Renewed,
+		&ent.Expires,
+		&ent.Created,
+	)
+	if err != nil {
 		return err
 	}
 
-	return service.Set(&ent.User, bytes, uuid.FromBytes)
+	return problem.Join(
+		service.Set(&ent.Token, bytes1, token_from_bytes),
+		service.Set(&ent.User, bytes2, uuid.FromBytes),
+	)
+}
+
+func token_from_bytes(bytes []byte) (session.Token, error) {
+	if len(bytes) != session.TokenLen {
+		return session.Token{}, session.ErrInvalidToken
+	}
+
+	return session.Token(bytes), nil
 }
 
 const (

--- a/internal/domain/session/token.go
+++ b/internal/domain/session/token.go
@@ -1,0 +1,33 @@
+package session
+
+import (
+	"crypto/rand"
+	"sync"
+)
+
+var (
+	pool   [32 * 256]byte
+	offset = len(pool)
+
+	mu sync.Mutex
+)
+
+func read(p []byte) (int, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(p) > len(pool) {
+		return rand.Read(p)
+	}
+
+	if len(pool[offset:]) < len(p) {
+		n := copy(p, pool[offset:])
+		rand.Read(pool[n:])
+		offset = 0
+	}
+
+	n := copy(p, pool[offset:])
+	offset += n
+
+	return n, nil
+}

--- a/internal/domain/session/xerrors.go
+++ b/internal/domain/session/xerrors.go
@@ -7,6 +7,7 @@ var (
 	ErrUpdate   = problem.Imp(problem.SemanticalError, "session-update").Message("could not update session")
 	ErrNotFound = problem.New(problem.NotFound, "session-not-found", "session not found", nil, nil)
 
-	ErrUnrenewable = problem.New(problem.SemanticalError, "session-renewed-exceeded", "session renewed too many times", nil, map[string]any{"max": MaxRenews})
-	ErrTooLong     = problem.New(problem.SemanticalError, "session-too-long", "session too long", nil, map[string]any{"max": MaxAgeMax})
+	ErrInvalidToken = problem.Imp(problem.Malformed, "invalid-token").Format("token cannot be parsed in %d byte array").Make(TokenLen)
+	ErrUnrenewable  = problem.New(problem.SemanticalError, "session-renewed-exceeded", "session renewed too many times", nil, map[string]any{"max": MaxRenews})
+	ErrTooLong      = problem.New(problem.SemanticalError, "session-too-long", "session too long", nil, map[string]any{"max": MaxAgeMax})
 )

--- a/internal/domain/session/xerrors.go
+++ b/internal/domain/session/xerrors.go
@@ -7,7 +7,7 @@ var (
 	ErrUpdate   = problem.Imp(problem.SemanticalError, "session-update").Message("could not update session")
 	ErrNotFound = problem.New(problem.NotFound, "session-not-found", "session not found", nil, nil)
 
-	ErrInvalidToken = problem.Imp(problem.Malformed, "invalid-token").Format("token cannot be parsed in %d byte array").Make(TokenLen)
+	ErrInvalidToken = problem.Imp(problem.Malformed, "invalid-token").Format("token cannot be parsed into %d byte array").Make(TokenLen)
 	ErrUnrenewable  = problem.New(problem.SemanticalError, "session-renewed-exceeded", "session renewed too many times", nil, map[string]any{"max": MaxRenews})
 	ErrTooLong      = problem.New(problem.SemanticalError, "session-too-long", "session too long", nil, map[string]any{"max": MaxAgeMax})
 )

--- a/internal/domain/user/store/sqlite.go
+++ b/internal/domain/user/store/sqlite.go
@@ -29,7 +29,7 @@ const Indexes = `create unique index if not exists Users_siape on Users(siape);`
 
 const Views = `
 create view if not exists Users_View as
-	select u.uuid, u.siape, u.name, u.email, u.password, iif(p.uuid is null, u.role, 'promoted-admin') as 'role', s.uuid is not null as 'logged', u.created, u.updated
+	select u.uuid, u.siape, u.name, u.email, u.password, iif(p.uuid is null, u.role, 'promoted-admin') as 'role', s.token is not null as 'logged', u.created, u.updated
 	from Users u
 	left join Sessions s on s.user = u.uuid
 	left join Promotions p on p.user = u.uuid;`

--- a/internal/support/service/service.go
+++ b/internal/support/service/service.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 
 	"github.com/alan-b-lima/almodon/internal/domain/auth"
+	"github.com/alan-b-lima/almodon/internal/domain/session"
 
 	"github.com/alan-b-lima/almodon/pkg/rbac"
-	"github.com/alan-b-lima/almodon/pkg/uuid"
 
 	"github.com/alan-b-lima/pkg/problem"
 )
@@ -22,7 +22,7 @@ func AuthorizeFromContext(ctx context.Context, gate auth.Authenticator, perms rb
 }
 
 func ActorFromContext(ctx context.Context, gate auth.Authenticator) (auth.Actor, error) {
-	session, ok := ctx.Value("session").(uuid.UUID)
+	session, ok := ctx.Value("session").(session.Token)
 	if !ok {
 		return auth.NewUnlogged(), nil
 	}


### PR DESCRIPTION
Como citado em #55, UUIDs não devem ser usados para identificação de recursos de segurança.

Assim foi implementado um sistema de hash criptográfico, com uma pool similar àquela para geração de UUIDs. Os novos identificadores são chamados de _tokens_, são arranjos de 24 bytes aleatórios.

Também adapta todas as API's que dependiam em UUIDs das sessões. resolve #55.