### PR TITLE
Adicionar testes de autenticação por HTTP

### DIFF
--- a/internal/domain/auth/resource/http_auth_test.go
+++ b/internal/domain/auth/resource/http_auth_test.go
@@ -1,0 +1,172 @@
+package auths_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alan-b-lima/almodon/internal/almodon"
+	"github.com/alan-b-lima/almodon/internal/domain"
+	"github.com/alan-b-lima/almodon/internal/domain/auth"
+	"github.com/alan-b-lima/almodon/internal/domain/user"
+)
+
+func init() {
+	api, err := almodon.NewAPI(domain.InMemory, ^domain.RootUser)
+	if err != nil {
+		panic(err)
+	}
+
+	users := api.Cores.Users
+
+	root_user := user.Create{
+		SIAPE:    "0000000",
+		Name:     "Raiz",
+		Email:    "noreply@ufvjm.edu.br",
+		Password: "12345678",
+		Role:     auth.Maintainer,
+	}
+
+	if _, err := users.Create(context.Background(), root_user); err != nil {
+		panic(err)
+	}
+
+	go http.ListenAndServe(":4545", api)
+
+	time.Sleep(300 * time.Millisecond)
+}
+
+func TestLogin(t *testing.T) {
+	req, err := http.NewRequest(
+		http.MethodPost,
+		"http://localhost:4545/api/v1/auth/",
+		strings.NewReader(`{"siape":"0000000","password":"12345678"}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+
+	var client http.Client
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(resp.StatusCode, err)
+		}
+
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+
+	if len(resp.Cookies()) == 0 {
+		t.Fatal("expected session cookie after login")
+	}
+}
+
+func TestLoginWithInvalidPassword(t *testing.T) {
+	req, err := http.NewRequest(
+		http.MethodPost,
+		"http://localhost:4545/api/v1/auth/",
+		strings.NewReader(`{"siape":"0000000","password":"senha-incorreta"}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+
+	var client http.Client
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 400 {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(resp.StatusCode, err)
+		}
+
+		t.Fatalf("expected authentication error, got status=%d body=%s", resp.StatusCode, body)
+	}
+}
+
+func TestLogout(t *testing.T) {
+	var client http.Client
+
+	login_req, err := http.NewRequest(
+		http.MethodPost,
+		"http://localhost:4545/api/v1/auth/",
+		strings.NewReader(`{"siape":"0000000","password":"12345678"}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	login_req.Header.Add("Content-Type", "application/json")
+	login_req.Header.Add("Accept", "application/json")
+
+	login_resp, err := client.Do(login_req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer login_resp.Body.Close()
+
+	if login_resp.StatusCode >= 400 {
+		body, err := io.ReadAll(login_resp.Body)
+		if err != nil {
+			t.Fatal(login_resp.StatusCode, err)
+		}
+
+		t.Fatalf("status=%d body=%s", login_resp.StatusCode, body)
+	}
+
+	cookies := login_resp.Cookies()
+	if len(cookies) == 0 {
+		t.Fatal("expected session cookie after login")
+	}
+
+	logout_req, err := http.NewRequest(
+		http.MethodDelete,
+		"http://localhost:4545/api/v1/auth/",
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logout_req.Header.Add("Accept", "application/json")
+
+	for _, cookie := range cookies {
+		logout_req.AddCookie(cookie)
+	}
+
+	logout_resp, err := client.Do(logout_req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer logout_resp.Body.Close()
+
+	if logout_resp.StatusCode >= 400 {
+		body, err := io.ReadAll(logout_resp.Body)
+		if err != nil {
+			t.Fatal(logout_resp.StatusCode, err)
+		}
+
+		t.Fatalf("status=%d body=%s", logout_resp.StatusCode, body)
+	}
+}


### PR DESCRIPTION
Added authentication HTTP tests under `internal/domain/auth/resource`.

Added a successful login test using valid root credentials.

Added a failed login test using an invalid password.

Added a logout test using the session cookie returned by the login request.