### PR TITLE
Implementar garantias de migração como pacote independente

### DIFF
--- a/pkg/migration/binary.go
+++ b/pkg/migration/binary.go
@@ -1,0 +1,61 @@
+package migration
+
+import (
+	"encoding/binary"
+	"errors"
+	"slices"
+)
+
+func (m Migration) LenBinary() int {
+	// sizeof(m.hash) + sizeof(len(m.scripts)) + sizeof(m.hash) * len(m.scripts)
+	return len(Hash{}) + 8 + len(Hash{})*len(m.scripts)
+}
+
+func (m Migration) AppendBinary(buf []byte) ([]byte, error) {
+	buf = slices.Grow(buf, m.LenBinary())
+
+	buf = append(buf, m.hash[:]...)
+	buf = binary.LittleEndian.AppendUint64(buf, uint64(len(m.scripts)))
+	for _, hash := range m.scripts {
+		buf = append(buf, hash[:]...)
+	}
+
+	return buf, nil
+}
+
+func (m Migration) MarshalBinary() ([]byte, error) {
+	return m.AppendBinary(nil)
+}
+
+var ErrInvalidBinary = errors.New("migration: invalid binary encoding")
+
+func (m *Migration) UnmarshalBinary(buf []byte) error {
+	if len(buf) < len(Hash{})+8 {
+		return ErrInvalidBinary
+	}
+
+	var hash Hash
+	n := copy(hash[:], buf)
+	buf = buf[n:]
+
+	size := binary.LittleEndian.Uint64(buf)
+	buf = buf[8:]
+
+	if len(buf) < len(Hash{})*int(size) {
+		return ErrInvalidBinary
+	}
+
+	scripts := make([]Hash, 0, size)
+	for range size {
+		var hash Hash
+		n := copy(hash[:], buf)
+		scripts = append(scripts, hash)
+		buf = buf[n:]
+	}
+
+	*m = Migration{
+		hash:    hash,
+		scripts: scripts,
+	}
+	return nil
+}

--- a/pkg/migration/binary_test.go
+++ b/pkg/migration/binary_test.go
@@ -1,0 +1,48 @@
+package migration_test
+
+import (
+	crand "crypto/rand"
+	"io"
+	"math/rand/v2"
+	"strings"
+	"testing"
+
+	. "github.com/alan-b-lima/almodon/pkg/migration"
+)
+
+func FuzzInversabilityOfBinaryEncoding(f *testing.F) {
+	const numEntries, nameLen, entryLen int64 = 4, 10, 62
+	f.Add(numEntries, nameLen, entryLen)
+
+	f.Fuzz(func(t *testing.T, e, nl, el int64) {
+		if e < 0 || nl <= 0 || el <= 0 {
+			return
+		}
+
+		sources := make(map[string]string, e)
+		for range e {
+			var b1, b2 strings.Builder
+
+			io.CopyN(&b1, crand.Reader, rand.N(nl))
+			io.CopyN(&b2, crand.Reader, rand.N(el))
+
+			sources[b1.String()] = b2.String()
+		}
+
+		mIn := New(sources)
+
+		b, err := mIn.MarshalBinary()
+		if err != nil {
+			t.Error(err)
+		}
+
+		var mOut Migration
+		if err := mOut.UnmarshalBinary(b); err != nil {
+			t.Error(err)
+		}
+
+		if cmp := mIn.Compare(&mOut); cmp != Equal {
+			t.Errorf("expected to be equal, got %v", cmp)
+		}
+	})
+}

--- a/pkg/migration/binary_test.go
+++ b/pkg/migration/binary_test.go
@@ -41,7 +41,7 @@ func FuzzInversabilityOfBinaryEncoding(f *testing.F) {
 			t.Error(err)
 		}
 
-		if cmp := mIn.Compare(&mOut); cmp != Equal {
+		if cmp := mIn.Compare(&mOut); cmp != Identical {
 			t.Errorf("expected to be equal, got %v", cmp)
 		}
 	})

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -19,35 +19,39 @@ type Hash [32]byte
 type Rel uint8
 
 const (
-	Equal Rel = iota
+	Identical Rel = iota
 	Upgradable
 	Incompatible
 )
 
 // New creates a new migration from the given sources. The migration's hash is
 // computed from the sources' names and contents, and its scripts are the
-// hashes of the sources' contents, sorted in ascending order.
+// hashes of the sources' contents, sorted in ascending order. As of the Go
+// spec, this algorithm does not depend on the order of iteration of the
+// given sources' map.
 //
 // Migrations created from the same input are semantically and deeply equal,
 // although not comparable by Go semantics. See [Migration.Compare] for more
 // advanced usage.
 func New(sources map[string]string) *Migration {
 	scripts := make([]Hash, 0, len(sources))
-	h := sha512.New512_256()
 
 	for name, source := range sources {
-		hs := hmac.New(sha512.New512_256, []byte(name))
-		hs.Write([]byte(source))
+		h := hmac.New(sha512.New512_256, []byte(name))
+		h.Write([]byte(source))
 
-		script := Hash(hs.Sum(nil))
+		script := Hash(h.Sum(nil))
 		scripts = append(scripts, script)
-
-		h.Write(script[:])
 	}
 
 	slices.SortFunc(scripts, func(a, b Hash) int {
 		return bytes.Compare(a[:], b[:])
 	})
+
+	h := sha512.New512_256()
+	for _, hash := range scripts {
+		h.Write(hash[:])
+	}
 
 	return &Migration{
 		hash:    Hash(h.Sum(nil)),
@@ -74,8 +78,8 @@ func (m *Migration) IsValid() bool {
 // Compare compares whether migrations are the same, a proper subset of one
 // another or incompatible.
 //
-// Migrations are the same if, and only if, they have the same hash. [Equal] is
-// returned.
+// Migrations are the same if, and only if, they have the same hash.
+// [Identical] is returned.
 //
 // A previous migration is a proper subset of the next if all scripts in the
 // previous migration are present in the next and they have the same hash. In
@@ -85,7 +89,7 @@ func (m *Migration) IsValid() bool {
 // Otherwise, they are incompatible, and [Incompatible] is returned.
 func (prev *Migration) Compare(next *Migration) Rel {
 	if prev.hash == next.hash {
-		return Equal
+		return Identical
 	}
 
 	if len(prev.scripts) >= len(next.scripts) {
@@ -105,7 +109,7 @@ func (prev *Migration) Compare(next *Migration) Rel {
 			i-- // effectively advance only the next's script.
 
 		case -1:
-			// if a smaller script is found in the next migration, then the
+			// if a greater script is found in the next migration, then the
 			// current prev's script is missing.
 			return Incompatible
 		}
@@ -126,7 +130,7 @@ func (h Hash) String() string {
 }
 
 var rels = [...]string{
-	Equal:        "equal",
+	Identical:    "identical",
 	Upgradable:   "upgradable",
 	Incompatible: "incompatible",
 }

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -1,0 +1,140 @@
+package migration
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha512"
+	"encoding/hex"
+	"slices"
+	"strconv"
+)
+
+type Migration struct {
+	hash    Hash
+	scripts []Hash
+}
+
+type Hash [32]byte
+
+type Rel uint8
+
+const (
+	Equal Rel = iota
+	Upgradable
+	Incompatible
+)
+
+// New creates a new migration from the given sources. The migration's hash is
+// computed from the sources' names and contents, and its scripts are the
+// hashes of the sources' contents, sorted in ascending order.
+//
+// Migrations created from the same input are semantically and deeply equal,
+// although not comparable by Go semantics. See [Migration.Compare] for more
+// advanced usage.
+func New(sources map[string]string) *Migration {
+	scripts := make([]Hash, 0, len(sources))
+	h := sha512.New512_256()
+
+	for name, source := range sources {
+		hs := hmac.New(sha512.New512_256, []byte(name))
+		hs.Write([]byte(source))
+
+		script := Hash(hs.Sum(nil))
+		scripts = append(scripts, script)
+
+		h.Write(script[:])
+	}
+
+	slices.SortFunc(scripts, func(a, b Hash) int {
+		return bytes.Compare(a[:], b[:])
+	})
+
+	return &Migration{
+		hash:    Hash(h.Sum(nil)),
+		scripts: scripts,
+	}
+}
+
+// IsValid reports whether the migration is valid, its hash is consistent with
+// its scripts and its scripts are sorted in ascending order.
+func (m *Migration) IsValid() bool {
+	h := sha512.New512_256()
+
+	for i, hash := range m.scripts {
+		if i > 0 && bytes.Compare(m.scripts[i-1][:], hash[:]) < 0 {
+			return false
+		}
+
+		h.Write(hash[:])
+	}
+
+	return m.hash == Hash(h.Sum(nil))
+}
+
+// Compare compares whether migrations are the same, a proper subset of one
+// another or incompatible.
+//
+// Migrations are the same if, and only if, they have the same hash. [Equal] is
+// returned.
+//
+// A previous migration is a proper subset of the next if all scripts in the
+// previous migration are present in the next and they have the same hash. In
+// this case, the next migration can be applied on top of the previous one, and
+// [Upgradable] is returned.
+//
+// Otherwise, they are incompatible, and [Incompatible] is returned.
+func (prev *Migration) Compare(next *Migration) Rel {
+	if prev.hash == next.hash {
+		return Equal
+	}
+
+	if len(prev.scripts) >= len(next.scripts) {
+		// prev cannot be a subset of a next set bigger than it, and if they
+		// are equal size, then their hashes should have been equal.
+		return Incompatible
+	}
+
+	for i, j := 0, 0; i < len(prev.scripts); i, j = i+1, j+1 {
+		iscript, jscript := prev.scripts[i], next.scripts[j]
+
+		switch bytes.Compare(iscript[:], jscript[:]) {
+		case 0:
+			continue
+
+		case 1:
+			i-- // effectively advance only the next's script.
+
+		case -1:
+			// if a smaller script is found in the next migration, then the
+			// current prev's script is missing.
+			return Incompatible
+		}
+	}
+
+	return Upgradable
+}
+
+func (m Migration) Hash() Hash      { return m.hash }
+func (m Migration) Scripts() []Hash { return slices.Clone(m.scripts) }
+
+func (m Migration) String() string {
+	return m.hash.String() + "(" + strconv.Itoa(len(m.scripts)) + ")"
+}
+
+func (h Hash) String() string {
+	return hex.EncodeToString(h[:])
+}
+
+var rels = [...]string{
+	Equal:        "equal",
+	Upgradable:   "upgradable",
+	Incompatible: "incompatible",
+}
+
+func (r Rel) String() string {
+	if r < Rel(len(rels)) {
+		return rels[r]
+	}
+
+	return "rel(" + strconv.Itoa(int(r)) + ")"
+}

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -17,7 +17,12 @@ func TestMigration(t *testing.T) {
 		{
 			Prev: map[string]string{"a.go": "Hello, World"},
 			Next: map[string]string{"a.go": "Hello, World"},
-			Want: Equal,
+			Want: Identical,
+		},
+		{
+			Prev: map[string]string{"a.go": "Hello, World", "b.go": "Hello, World"},
+			Next: map[string]string{"b.go": "Hello, World", "a.go": "Hello, World"},
+			Want: Identical,
 		},
 		{
 			Prev: map[string]string{"a.go": "Hello, World"},

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -1,0 +1,47 @@
+package migration_test
+
+import (
+	"testing"
+
+	. "github.com/alan-b-lima/almodon/pkg/migration"
+)
+
+func TestMigration(t *testing.T) {
+	type Test struct {
+		Prev map[string]string
+		Next map[string]string
+		Want Rel
+	}
+
+	tests := []Test{
+		{
+			Prev: map[string]string{"a.go": "Hello, World"},
+			Next: map[string]string{"a.go": "Hello, World"},
+			Want: Equal,
+		},
+		{
+			Prev: map[string]string{"a.go": "Hello, World"},
+			Next: map[string]string{"a.go": "Hello, World", "b.go": "Hello, World"},
+			Want: Upgradable,
+		},
+		{
+			Prev: map[string]string{"a.go": "Hello, World", "b.go": "Hello, World"},
+			Next: map[string]string{"a.go": "Hello, World", "b2.go": "Hello, World"},
+			Want: Incompatible,
+		},
+		{
+			Prev: map[string]string{"a.go": "Hello, World"},
+			Next: map[string]string{"a.go": "Goodbye, World"},
+			Want: Incompatible,
+		},
+	}
+
+	for _, test := range tests {
+		prev := New(test.Prev)
+		next := New(test.Next)
+
+		if got := prev.Compare(next); got != test.Want {
+			t.Errorf("want %v, got %v", test.Want, got)
+		}
+	}
+}


### PR DESCRIPTION
Exercitando conhecimentos de criptografia, implementei garantias de migração usando hashificação com SHA-256/512.

O pacote funciona da seguinte maneira: uma migração é uma instância onde se busca executar um conjunto de scripts, não necessariamente precisa ter havido mudanças. Cada migração pode ser de três categorias mutualmente exclusivas, considere $`M_1`$ e $`M_2`$:

- Idêntico: $`M_1 = M_2`$
- Atualizável: $`M_1 \subset M_2 \land M_1 \not= M_2`$
- Incompatível: $`M_1 \not\subset M_2`$

Isso é puramente computado através de hashs, sendo uma solução bastante compacta.